### PR TITLE
🎨多线程压缩面板图

### DIFF
--- a/WutheringWavesUID/utils/image.py
+++ b/WutheringWavesUID/utils/image.py
@@ -377,7 +377,7 @@ def draw_text_with_shadow(
     image.text((_x, _y), text, font=font, fill=fill_color, anchor=anchor)
 
 
-async def compress_to_webp(
+def compress_to_webp(
     image_path: Path, quality: int = 80, delete_original: bool = False
 ) -> tuple[bool, Path]:
     try:


### PR DESCRIPTION
仅仅将压缩部分改为多线程，使用 总线程数-2 避免卡死

性能利用率如图

![image](https://github.com/user-attachments/assets/8942669d-96cb-4ddd-ab22-1fc9a0f6b82c)

557张面板图大约耗时15秒压缩完成，否则耗时4分钟并会导致压缩完成反馈消息被吞掉

![image](https://github.com/user-attachments/assets/35008f29-5f0c-440f-ae17-2ad9a2f44aa2)

考虑到足够快，无需处理阻塞